### PR TITLE
Add pipe to remove empty anchor

### DIFF
--- a/modules/clean.js
+++ b/modules/clean.js
@@ -67,6 +67,18 @@ export function clean() {
 				})
 			)
 
+			// remove empty anchor tags
+			.pipe(
+				dom(function () {
+					const anchors = this.querySelectorAll("a");
+					return anchors.forEach((anchor) => {
+						if (anchor.textContent.trim() === "") {
+							anchor.remove();
+						}
+					});
+				})
+			)
+
       // beautify code
 			.pipe(
 				beautify({


### PR DESCRIPTION
Added pipe to the clean function. Pipe selects all <a> tags, loops through them to find those without textContent and removes them.