### PR TITLE
Edited iframe scanning to account for h5p iframes being wrapped in divs

### DIFF
--- a/modules/log/checkIframeTitles.js
+++ b/modules/log/checkIframeTitles.js
@@ -1,7 +1,7 @@
 export function checkIframeTitles(document, filePath, errors, stringsToCheck) {
   // Get all iframes from the document
   let iframes = Array.from(document.querySelectorAll('iframe'));
-  stringsToCheck= ["YouTube video player"];
+  stringsToCheck = ["YouTube video player"];
 
   // Check each iframe
   iframes.forEach(iframe => {
@@ -9,10 +9,9 @@ export function checkIframeTitles(document, filePath, errors, stringsToCheck) {
     let title = iframe.getAttribute('title');
 
     // If the iframe's src starts with "https://pima.h5p.com", skip it completely
-    if (src && (src.startsWith("https://pima.h5p.com") || src.includes("/d2l/common/dialogs/quickLink/quickLink"))) {
+    if (src && (src.startsWith("https://pima.h5p.com") || src.includes("/d2l/common/dialogs/quickLink/quickLink") || src.includes("h5p"))) {
       return;
     }
-    
 
     let parent = iframe.parentElement;
     let foundMediaObject = false;

--- a/modules/log/checkIframes.js
+++ b/modules/log/checkIframes.js
@@ -6,8 +6,28 @@ export function checkIframes(document, filePath, errors) {
   iframes.forEach(iframe => {
     let src = iframe.getAttribute('src');
 
+    // Check if the iframe uses h5p and if it does, ensure it is wrapped in a div
+    if (src && src.includes("/d2l/common/dialogs/quickLink") || src.includes("https://pima.h5p.com/content") || src.includes("h5p")) {
+      let parent = iframe.parentElement;
+
+      // Check if the iframe is contained within a div with the class 'media-object'
+      while (parent !== null) {
+        if (parent.tagName.toLowerCase() === 'div') {
+          return;
+        }
+        parent = parent.parentElement;
+      }
+
+      // If the iframe is not contained within a div with the class 'media-object', add an error
+      if (!errors[filePath]) {
+        errors[filePath] = [];
+      }
+      errors[filePath].push('Invalid iframes detected (h5p iframe not contained within \'div\' tag)');
+    }
+
     // Check if the iframe's src attribute includes specific URLs
     if (src && (src.includes('https://www.youtube.com') || src.includes('https://pima-cc.hosted.panopto.com'))) {
+
       let parent = iframe.parentElement;
 
       // Check if the iframe is contained within a div with the class 'media-object'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "code-cleaner",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "code-cleaner",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "jsdom": "^22.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-cleaner",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "This code cleaner app is a code cleaning automation tool designed to format and log errors for the markup used to build courses with the PimaOnline Themepack.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
A lot of courses have `iframes` wrapped in <p> tags just because I believe it is D2L default behavior. 

This update will help `iframes` wrapped in <p> tags get read and flagged for fixing. This change affects only `iframes` that are using `h5p` to use empty <div> tags. 

I tried to create a function to replicate a lot of the code for the other `iframe` check in the `checkIframes.js file`, but there was a lot of criteria that was different, so they are in their own similar little bits of code. 