### PR TITLE
Added functions to check for img attributes and parent elements

### DIFF
--- a/modules/log/checkImgAlt.js
+++ b/modules/log/checkImgAlt.js
@@ -1,13 +1,40 @@
 export function checkImgAlt(document, filePath, errors) {
+
+	// Helper function to log errors
+  const logError = (message) => {
+    if (!errors[filePath]) {
+      errors[filePath] = [];
+    }
+    errors[filePath].push(message);
+  };
+
   // Get all <img> elements
   let imgElements = document.querySelectorAll('img');
 
   imgElements.forEach((img) => {
+    // Check if alt attribute is missing
     if (!img.hasAttribute('alt')) {
-      if (!errors[filePath]) {
-        errors[filePath] = [];
-      }
-      errors[filePath].push('An <img> element is missing its alt attribute');
+      // Check if the <img> is inside a <figure> with a <figcaption>
+      const parent = img.parentElement;
+      if (!parent || parent.tagName !== 'FIGURE' || !parent.querySelector('figcaption')) {
+        logError('An <img> element is missing its alt attribute and is not inside a <figure> with a <figcaption>');
+      } else {
+				// Check if <img> is inside a <figure> with a <figcaption>, but missing alt attribute
+				logError('An <img> within a <figure> element is missing its alt attribute');
     }
+	}
+
+    // Check if <img> is inside a <p> tag
+    if (img.parentElement && img.parentElement.tagName === 'P') {
+      logError('An <img> element is inside a <p> tag');
+    }
+
+    // Check for unnecessary attributes
+    const attributes = ['decoding', 'fetchpriority', 'height', 'loading', 'srcset', 'style', 'sizes', 'width'];
+    attributes.forEach((attribute) => {
+      if (img.hasAttribute(attribute)) {
+        logError(`An <img> element contains the attribute: ${attribute}`);
+      }
+    });
   });
 }


### PR DESCRIPTION
Created additional functions within existing img check to log:
- missing alt tags, with and without figure/figcaption parent
- unnecessary inline attributes (decoding, fetchpriority, height, loading, srcset, style, sizes, width)
- parent element is a `<p>` tag