### PR TITLE
Skip youtube placeholder iframes from log

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,5 +4,8 @@ export const config = {
 
 	// Specify the classes that should be applied to vertical tables
 	vertTableClasses: ["vert-table", "display-vertical", "display-vert"],
-
+  // iframe titles that should be logged
+  titlesToCheck: ["YouTube video player"],
+  // Skips certain iframes like youtube placeholder
+  iframesToExclude: ["https://www.youtube.com/embed/NpEaa2P7qZI?si=DFcFec4auMcyTLXX"],
 };

--- a/modules/log/checkIframeTitles.js
+++ b/modules/log/checkIframeTitles.js
@@ -1,7 +1,9 @@
-export function checkIframeTitles(document, filePath, errors, stringsToCheck) {
+export function checkIframeTitles(document, filePath, errors, stringsToCheck, urlsToExclude) {
   // Get all iframes from the document
   let iframes = Array.from(document.querySelectorAll('iframe'));
   stringsToCheck = ["YouTube video player"];
+  // Skips YouTube placeholder iframes
+  urlsToExclude = ["https://www.youtube.com/embed/NpEaa2P7qZI?si=DFcFec4auMcyTLXX"];
 
   // Check each iframe
   iframes.forEach(iframe => {
@@ -44,7 +46,8 @@ export function checkIframeTitles(document, filePath, errors, stringsToCheck) {
     // If 'media-container' does not have a 'media-info' sibling, check the iframe's title attribute
     if (!hasMediaInfoSibling && title) {
       stringsToCheck.forEach(str => {
-        if (title.includes(str)) {
+        // Exclude Youtube placeholder iframes from log since those have the default title attr
+        if (!urlsToExclude.some(url => src && src.includes(url)) && title.includes(str)) {
           if (!errors[filePath]) {
             errors[filePath] = [];
           }

--- a/modules/log/checkIframeTitles.js
+++ b/modules/log/checkIframeTitles.js
@@ -1,9 +1,11 @@
-export function checkIframeTitles(document, filePath, errors, stringsToCheck, urlsToExclude) {
+import { config } from "../../config.js";
+
+const titlesToCheck = config.titlesToCheck;
+const iframesToExclude = config.iframesToExclude;
+
+export function checkIframeTitles(document, filePath, errors) {
   // Get all iframes from the document
   let iframes = Array.from(document.querySelectorAll('iframe'));
-  stringsToCheck = ["YouTube video player"];
-  // Skips YouTube placeholder iframes
-  urlsToExclude = ["https://www.youtube.com/embed/NpEaa2P7qZI?si=DFcFec4auMcyTLXX"];
 
   // Check each iframe
   iframes.forEach(iframe => {
@@ -45,9 +47,9 @@ export function checkIframeTitles(document, filePath, errors, stringsToCheck, ur
 
     // If 'media-container' does not have a 'media-info' sibling, check the iframe's title attribute
     if (!hasMediaInfoSibling && title) {
-      stringsToCheck.forEach(str => {
+      titlesToCheck.forEach(str => {
         // Exclude Youtube placeholder iframes from log since those have the default title attr
-        if (!urlsToExclude.some(url => src && src.includes(url)) && title.includes(str)) {
+        if (!iframesToExclude.some(url => src && src.includes(url)) && title.includes(str)) {
           if (!errors[filePath]) {
             errors[filePath] = [];
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-cleaner",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "This code cleaner app is a code cleaning automation tool designed to format and log errors for the markup used to build courses with the PimaOnline Themepack.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Create array of video urls to skip
- Youtube placeholder video will have the generic title attr so we want to skip that from the error logs
- Add condition to skip it during title check