### PR TITLE
Added function to find error reference path

### DIFF
--- a/modules/log/checkContentBody.js
+++ b/modules/log/checkContentBody.js
@@ -1,11 +1,8 @@
+import { logError } from "./utilities/logError.js"
+
 export function checkContentBody(document, filePath, errors) {
   // List of invalid nested elements
-  const nestedElements = ['.content-body', 'header']; 
-
-  // Ensure errors[filePath] exists
-  if (!errors[filePath]) {
-    errors[filePath] = [];
-  }
+  const nestedElements = ['.content-body', 'header'];
 
   // Get all elements with the class 'content-body' from the document
   const contentBodies = Array.from(document.querySelectorAll('.content-body'));
@@ -18,7 +15,7 @@ export function checkContentBody(document, filePath, errors) {
     nestedElements.forEach(nestedElement => {
       const invalidNestedElements = contentBody.querySelectorAll(nestedElement);
       invalidNestedElements.forEach(() => {
-        errors[filePath].push(`An invalid '${nestedElement}' is nested within a '.content-body'`);
+        logError(contentBody, `An invalid '${nestedElement}' is nested within a '.content-body'`, filePath, errors);
       });
     });
   };
@@ -42,7 +39,7 @@ export function checkContentBody(document, filePath, errors) {
 
     // Check if the content body is inside a valid parent
     if (!checkValidParent(contentBody)) {
-      errors[filePath].push("A 'content-body' is not inside #content-wrapper, #second-column, or #third-column");
+      logError(contentBody, `A 'content-body' is not inside #content-wrapper, #second-column, or #third-column`, filePath, errors);
     }
   });
 }

--- a/modules/log/checkContentWrapper.js
+++ b/modules/log/checkContentWrapper.js
@@ -1,12 +1,11 @@
+import { logError } from "./utilities/logError.js"
+
 export function checkContentWrapper(document, filePath, errors) {
   // Check if the document contains a div with the id 'content-wrapper'
   let contentWrapper = document.querySelector('div#content-wrapper');
+
   if (!contentWrapper) {
-    // Initialize the errors array for the file path if it doesn't exist
-    if (!errors[filePath]) {
-      errors[filePath] = [];
-    }
-    // Add the error message to the errors array for the file path
-    errors[filePath].push("Missing '#content-wrapper'");
+    // Log the error using the logError function
+    logError(document, "Missing '#content-wrapper'", filePath, errors);
   }
 }

--- a/modules/log/checkDeprecatedClasses.js
+++ b/modules/log/checkDeprecatedClasses.js
@@ -1,3 +1,5 @@
+import { logError } from "./utilities/logError.js"
+
 export function checkDeprecatedClasses(document, filePath, errors) {
   // Define the deprecated classes
   let deprecatedClasses = ['main', 'main-two-column', 'sidebar', 'video-container'];
@@ -12,10 +14,7 @@ export function checkDeprecatedClasses(document, filePath, errors) {
 
     // If there are elements with the deprecated class or id, add an error
     if (elementsWithDeprecatedClass.length > 0 || elementWithDeprecatedId) {
-      if (!errors[filePath]) {
-        errors[filePath] = [];
-      }
-      errors[filePath].push(`Contains deprecated class or id (${deprecatedClass})`);
+      logError(document, `Contains deprecated class or id (${deprecatedClass})`, filePath, errors);
     }
   });
 }

--- a/modules/log/checkDoctype.js
+++ b/modules/log/checkDoctype.js
@@ -1,11 +1,9 @@
+import { logError } from "./utilities/logError.js"
+
 export function checkDoctype(document, filePath, errors) {
   // Check if the document has a doctype and if it's HTML
   if (!document.doctype || document.doctype.name.toLowerCase() !== 'html') {
-    // Initialize the errors array for the file path if it doesn't exist
-    if (!errors[filePath]) {
-      errors[filePath] = [];
-    }
-    // Add the error message to the errors array for the file path
-    errors[filePath].push('Missing <!DOCTYPE html>');
+    // Log the error using the logError function
+    logError(document, 'Missing <!DOCTYPE html>', filePath, errors);
   }
 }

--- a/modules/log/checkHeader.js
+++ b/modules/log/checkHeader.js
@@ -1,3 +1,5 @@
+import { logError } from "./utilities/logError.js"
+
 export function checkHeader(document, filePath, errors) {
 	// Convert filePath to lowercase and check if it contains 'syllabus'
 	if (filePath.toLowerCase().includes("syllabus")) {
@@ -7,11 +9,7 @@ export function checkHeader(document, filePath, errors) {
 	// Check if the document contains a header with the class 'header'
 	let header = document.querySelector("header.header");
 	if (!header) {
-		// Initialize the errors array for the file path if it doesn't exist
-		if (!errors[filePath]) {
-			errors[filePath] = [];
-		}
-		// Add the error message to the errors array for the file path
-		errors[filePath].push("Missing <header class='header'></div>");
+		// Log the error using the logError function
+		logError(document, "Missing <header class='header'></div>", filePath, errors);
 	}
 }

--- a/modules/log/checkHeadings.js
+++ b/modules/log/checkHeadings.js
@@ -1,50 +1,35 @@
+import { logError } from "./utilities/logError.js"
+
 export function checkHeadings(document, filePath, errors) {
   const headings = Array.from(document.querySelectorAll("h1, h2, h3, h4, h5, h6"));
   let previousLevel = 0;
-	let h1Count = 0;
-	const h1Check = document.querySelector("h1");
+  let h1Count = 0;
+  const h1Check = document.querySelector("h1");
 
-	// Check if <h1> is present as the document title and <h2> follows
-	if (headings.length && h1Check && headings[0].tagName !== "H1") {
-		if (!errors[filePath]) {
-			errors[filePath] = [];
-		}
-		errors[filePath].push(`Invalid heading structure (document must start with an <h1> heading).`);
-	} else if (!headings.length) {
-		if (!errors[filePath]) {
-			errors[filePath] = [];
-		}
-		errors[filePath].push(`Invalid heading structure (no headings found).`);
-	} else if (headings.length && !h1Check) {
-		if (!errors[filePath]) {
-			errors[filePath] = [];
-		}
-		errors[filePath].push(`Invalid heading structure (no <h1> heading found).`);
-	}
+  // Check if <h1> is present as the document title and <h2> follows
+  if (headings.length && h1Check && headings[0].tagName !== "H1") {
+    logError(document, "Invalid heading structure (document must start with an <h1> heading).", filePath, errors);
+  } else if (!headings.length) {
+    logError(document, "Invalid heading structure (no headings found).", filePath, errors);
+  } else if (headings.length && !h1Check) {
+    logError(document, "Invalid heading structure (no <h1> heading found).", filePath, errors);
+  }
 
-	// Loop through each heading and check for errors
+  // Loop through each heading and check for errors
   headings.forEach((heading) => {
     const level = parseInt(heading.tagName[1]);
 
-		// Check if there are more than two <h1> headings
-		if(level === 1) {
-			h1Count++;
-			if(h1Count > 1) {
-				if (!errors[filePath]) {
-					errors[filePath] = [];
-				}
-				errors[filePath].push(`Invalid heading structure (more than one <h1> heading found).`);
-			}
-		}
+    // Check if there are more than two <h1> headings
+    if (level === 1) {
+      h1Count++;
+      if (h1Count > 1) {
+        logError(document, "Invalid heading structure (more than one <h1> heading found).", filePath, errors);
+      }
+    }
 
     // Check if heading levels skip (e.g., <h2> followed directly by <h4>)
     if (level > previousLevel + 1 && previousLevel !== 0) {
-			if (!errors[filePath]) {
-        errors[filePath] = [];
-      }
-				errors[filePath].push(
-					`Invalid heading structure (<${heading.tagName.toLowerCase()}> found after <h${previousLevel}>).`
-				);
+      logError(document, `Invalid heading structure (<${heading.tagName.toLowerCase()}> found after <h${previousLevel}>).`, filePath, errors);
     }
 
     // Update previousLevel to current heading level

--- a/modules/log/checkHtmlLang.js
+++ b/modules/log/checkHtmlLang.js
@@ -1,12 +1,10 @@
+import { logError } from "./utilities/logError.js"
+
 export function checkHtmlLang(document, filePath, errors) {
   // Check if the HTML element has a 'lang' attribute and if it's 'en'
   let html = document.querySelector('html');
   if (!html || html.getAttribute('lang') !== 'en') {
-    // Initialize the errors array for the file path if it doesn't exist
-    if (!errors[filePath]) {
-      errors[filePath] = [];
-    }
-    // Add the error message to the errors array for the file path
-    errors[filePath].push("Missing <html lang='en'>");
+    // Log the error using logError
+    logError(document, "Missing <html lang='en'>", filePath, errors);
   }
 }

--- a/modules/log/checkIframeTitles.js
+++ b/modules/log/checkIframeTitles.js
@@ -1,3 +1,4 @@
+import { logError } from "./utilities/logError.js"
 import { config } from "../../config.js";
 
 const titlesToCheck = config.titlesToCheck;
@@ -39,10 +40,7 @@ export function checkIframeTitles(document, filePath, errors) {
 
     // Log errors based on the checks
     if (!foundMediaObject || !foundMediaContainer) {
-      if (!errors[filePath]) {
-        errors[filePath] = [];
-      }
-      errors[filePath].push('Invalid iframe detected (not wrapped by \'.media-container\' and/or \'.media-object\').');
+      logError(iframe, 'Invalid iframe detected (not wrapped by \'.media-container\' and/or \'.media-object\').', filePath, errors);
     }
 
     // If 'media-container' does not have a 'media-info' sibling, check the iframe's title attribute
@@ -50,10 +48,7 @@ export function checkIframeTitles(document, filePath, errors) {
       titlesToCheck.forEach(str => {
         // Exclude Youtube placeholder iframes from log since those have the default title attr
         if (!iframesToExclude.some(url => src && src.includes(url)) && title.includes(str)) {
-          if (!errors[filePath]) {
-            errors[filePath] = [];
-          }
-          errors[filePath].push(`Invalid iframes detected (incorrect title attribute: "${str}".)`);
+          logError(iframe, `Invalid iframe detected (incorrect title attribute: "${str}".)`, filePath, errors);
         }
       });
     }

--- a/modules/log/checkIframes.js
+++ b/modules/log/checkIframes.js
@@ -1,3 +1,5 @@
+import { logError } from "./utilities/logError.js"
+
 export function checkIframes(document, filePath, errors) {
   // Get all iframes from the document
   let iframes = Array.from(document.querySelectorAll('iframe'));
@@ -7,7 +9,7 @@ export function checkIframes(document, filePath, errors) {
     let src = iframe.getAttribute('src');
 
     // Check if the iframe uses h5p and if it does, ensure it is wrapped in a div
-    if (src && src.includes("/d2l/common/dialogs/quickLink") || src.includes("https://pima.h5p.com/content") || src.includes("h5p")) {
+    if (src && (src.includes("/d2l/common/dialogs/quickLink") || src.includes("https://pima.h5p.com/content") || src.includes("h5p"))) {
       let parent = iframe.parentElement;
 
       // Check if the iframe is contained within a div with the class 'media-object'
@@ -18,16 +20,12 @@ export function checkIframes(document, filePath, errors) {
         parent = parent.parentElement;
       }
 
-      // If the iframe is not contained within a div with the class 'media-object', add an error
-      if (!errors[filePath]) {
-        errors[filePath] = [];
-      }
-      errors[filePath].push('Invalid iframes detected (h5p iframe not contained within \'div\' tag)');
+      // Log the error using logError
+      logError(iframe, 'Invalid iframe detected (h5p iframe not contained within a div tag)', filePath, errors);
     }
 
     // Check if the iframe's src attribute includes specific URLs
     if (src && (src.includes('https://www.youtube.com') || src.includes('https://pima-cc.hosted.panopto.com'))) {
-
       let parent = iframe.parentElement;
 
       // Check if the iframe is contained within a div with the class 'media-object'
@@ -38,11 +36,8 @@ export function checkIframes(document, filePath, errors) {
         parent = parent.parentElement;
       }
 
-      // If the iframe is not contained within a div with the class 'media-object', add an error
-      if (!errors[filePath]) {
-        errors[filePath] = [];
-      }
-      errors[filePath].push('Invalid iframes detected (not contained within \'.media-container\')');
+      // Log the error using logError
+      logError(iframe, 'Invalid iframe detected (not contained within a .media-object div)', filePath, errors);
     }
   });
 }

--- a/modules/log/checkImgAlt.js
+++ b/modules/log/checkImgAlt.js
@@ -1,13 +1,6 @@
+import { logError } from "./utilities/logError.js"
+
 export function checkImgAlt(document, filePath, errors) {
-
-  // Helper function to log errors
-  const logError = (message) => {
-    if (!errors[filePath]) {
-      errors[filePath] = [];
-    }
-    errors[filePath].push(message);
-  };
-
   // Get all <img> elements
   let imgElements = document.querySelectorAll('img');
 
@@ -19,29 +12,29 @@ export function checkImgAlt(document, filePath, errors) {
   
       if (isInHeader) {
         // If in a <header>, log a specific error for a missing alt attribute only
-        logError('A header <img> element is missing its alt attribute');
+        logError(img, 'A header <img> element is missing its alt attribute', filePath, errors);
       } else {
         // If not in a <header>, check if the <img> is inside a <figure> with a <figcaption>
         const parent = img.parentElement;
         if (!parent || parent.tagName !== 'FIGURE' || !parent.querySelector('figcaption')) {
-          logError('An <img> element is missing its alt attribute and is not inside a <figure> with a <figcaption>');
+          logError(img, 'An <img> element is missing its alt attribute and is not inside a <figure> with a <figcaption>', filePath, errors);
         } else {
           // <img> is inside a <figure> with a <figcaption> but missing alt attribute
-          logError('An <img> within a <figure> element is missing its alt attribute');
+          logError(img, 'An <img> within a <figure> element is missing its alt attribute', filePath, errors);
         }
       }
     }
 
     // Check if <img> is inside a <p> tag
     if (img.parentElement && img.parentElement.tagName === 'P') {
-      logError('An <img> element is inside a <p> tag');
+      logError(img, 'An <img> element is inside a <p> tag', filePath, errors);
     }
 
     // Check for unnecessary attributes
     const attributes = ['decoding', 'fetchpriority', 'height', 'loading', 'srcset', 'style', 'sizes', 'width'];
     attributes.forEach((attribute) => {
       if (img.hasAttribute(attribute)) {
-        logError(`An <img> element contains the attribute: ${attribute}`);
+        logError(img, `An <img> element contains the attribute: ${attribute}`, filePath, errors);
       }
     });
   });

--- a/modules/log/checkJquery.js
+++ b/modules/log/checkJquery.js
@@ -1,12 +1,10 @@
+import { logError } from "./utilities/logError.js"
+
 export function checkJquery(document, filePath, errors) {
 	// Check if the document contains the jquery script
 	let jqueryScript = document.querySelector('script[type="text/javascript"][src="https://cdn.jsdelivr.net/npm/jquery/dist/jquery.min.js"][defer]');
 	if (jqueryScript) {
-		// Initialize the errors array for the file path if it exist
-		if (!errors[filePath]) {
-			errors[filePath] = [];
-		}
-		// Add the error message to the errors array for the file path
-		errors[filePath].push("Head contains deprecated jquery script");
+		// Log the error with the path and message
+		logError(jqueryScript, "Head contains deprecated jquery script", filePath, errors);
 	}
 }

--- a/modules/log/checkJsScripts.js
+++ b/modules/log/checkJsScripts.js
@@ -1,3 +1,5 @@
+import { logError } from "./utilities/logError.js"
+
 export function checkScriptTagsLocation(document, filePath, errors) {
   // Get all <script> elements in the document
   const scriptElements = document.querySelectorAll("script");
@@ -5,10 +7,8 @@ export function checkScriptTagsLocation(document, filePath, errors) {
   scriptElements.forEach((script) => {
     // Check if the parent of the script is the <head> element
     if (script.parentElement.tagName.toLowerCase() !== 'head') {
-      if (!errors[filePath]) {
-        errors[filePath] = [];
-      }
-      errors[filePath].push("Invalid JS placement (a <script> element is located outside the <head> section)");
+      // Log the error with the path and message
+      logError(script, "Invalid JS placement (a <script> element is located outside the <head> section)", filePath, errors);
     }
   });
 }

--- a/modules/log/checkPanoptoContainer.js
+++ b/modules/log/checkPanoptoContainer.js
@@ -1,34 +1,27 @@
-// This requires a check for media container and media object even though it is found in checkIframeTitles.js because Panopto videos are lumped together with h5p videos in the same check. This is a separate check for Panopto videos only.
+import { logError } from "./utilities/logError.js"
 
 export function checkPanoptoWrapper(document, filePath, errors) {
-	// Get all panopto videos from the document - this uses the "rcode=PIMA" parameter in the URL
-	const panoptoVideos = Array.from(document.querySelectorAll('iframe[src*="rcode=PIMA"]'));
+  // Get all Panopto videos from the document - this uses the "rcode=PIMA" parameter in the URL
+  const panoptoVideos = Array.from(document.querySelectorAll('iframe[src*="rcode=PIMA"]'));
 
-	// Check each panopto video
-	panoptoVideos.forEach(panoptoVideo => {
-		let mediaObject = panoptoVideo.parentElement;
+  // Check each Panopto video
+  panoptoVideos.forEach(panoptoVideo => {
+    let mediaObject = panoptoVideo.parentElement;
 
-		// Check if the iframe is contained within a div with the class 'media-object'
-		if (mediaObject && mediaObject.tagName.toLowerCase() === 'div' && mediaObject.classList.contains('media-object')) {
+    // Check if the iframe is contained within a div with the class 'media-object'
+    if (mediaObject && mediaObject.tagName.toLowerCase() === 'div' && mediaObject.classList.contains('media-object')) {
+      let mediaContainer = mediaObject.parentElement;
 
-			let mediaContainer = mediaObject.parentElement;
-
-			// Check if the div with the class 'media-object' is contained within a div with the class 'media-container'
-			if(mediaContainer && mediaContainer.tagName.toLowerCase() === 'div' && mediaContainer.classList.contains('media-container')) {
-			} else {
-				if (!errors[filePath]) {
-					errors[filePath] = [];
-				}
-				// If the div with the class 'media-object' is not contained within a div with the class 'media-container', add an error
-				errors[filePath].push('Invalid iframes detected (panopto iframe not wrapped by \'.media-container\' and/or \'.media-object\')');
-			}
-		} else {
-			// No errors array for this file yet, create one
-			if (!errors[filePath]) {
-				errors[filePath] = [];
-			}
-			// If the iframe is not contained within a div with the class 'media-object', add an error
-			errors[filePath].push('Invalid iframes detected (panopto iframe not not wrapped by \'.media-container\' and/or \'.media-object\')');
-		}
-	});
+      // Check if the div with the class 'media-object' is contained within a div with the class 'media-container'
+      if (mediaContainer && mediaContainer.tagName.toLowerCase() === 'div' && mediaContainer.classList.contains('media-container')) {
+        // No errors, continue
+      } else {
+        // Log error if not wrapped by '.media-container' and/or '.media-object'
+        logError(panoptoVideo, 'Invalid iframes detected (Panopto iframe not wrapped by \'.media-container\' and/or \'.media-object\')', filePath, errors);
+      }
+    } else {
+      // Log error if the iframe is not wrapped by '.media-object'
+      logError(panoptoVideo, 'Invalid iframes detected (Panopto iframe not wrapped by \'.media-container\' and/or \'.media-object\')', filePath, errors);
+    }
+  });
 }

--- a/modules/log/checkTables.js
+++ b/modules/log/checkTables.js
@@ -1,7 +1,7 @@
 import { config } from '../../config.js';
+import { logError } from "./utilities/logError.js"
 
 const vertTableClasses = config.vertTableClasses;
-
 
 export function checkTables(document, filePath, errors) {
   // Get all tables from the document
@@ -9,44 +9,22 @@ export function checkTables(document, filePath, errors) {
 
   // Check each table
   tables.forEach(table => {
-    // Check if the table has the 'display-lg' class
-    if (!table.classList.contains('display-lg')) {
-
-			// Check if the table has any of the specified classes for vertical tables
-			if(!vertTableClasses.some(className => table.classList.contains(className))) {
-
-			// If the table does not have the 'display-lg' class or vertical table class, add an error
-			if (!errors[filePath]) {
-        errors[filePath] = [];
-      }
-      errors[filePath].push('A table does not contain \'.display-lg\'');
-		} 
+    // Check if the table has the 'display-lg' class and is missing a vertical table class
+    if (!table.classList.contains('display-lg') && !vertTableClasses.some(className => table.classList.contains(className))) {
+      logError(table, 'A table does not contain \'.display-lg\' or any vertical table class', filePath, errors);
     }
 
     // Check the structure of the table
     let thead = table.querySelector('thead');
     if (thead) {
       let tr = thead.querySelector('tr');
-      if (tr) {
-        if (tr.querySelectorAll('th[scope=\'col\']').length === 0) {
-          if (!errors[filePath]) {
-            errors[filePath] = [];
-          }
-          errors[filePath].push('A table does not contain the correct structure (missing <th scope=\'col\'> within <thead>)');
-        }
-      } else {
-        if (!errors[filePath]) {
-          errors[filePath] = [];
-        }
-        errors[filePath].push('A table does not contain the correct structure (missing <tr> within <thead>)');
+      if (tr && tr.querySelectorAll('th[scope="col"]').length === 0) {
+        logError(table, 'A table does not contain the correct structure (missing <th scope="col"> within <thead>)', filePath, errors);
       }
-    } else if(vertTableClasses.some(className => table.classList.contains(className))) {
-			// Check if the table has any of the specified classes for vertical tables, if not, then 
-		} else {
-      if (!errors[filePath]) {
-        errors[filePath] = [];
-      }
-      errors[filePath].push('A table does not contain the correct structure (missing <thead>)');
+    } else if (vertTableClasses.some(className => table.classList.contains(className))) {
+      // Skip this check for vertical tables as they might not require a <thead>
+    } else {
+      logError(table, 'A table does not contain the correct structure (missing <thead>)', filePath, errors);
     }
   });
 }

--- a/modules/log/checkTitleAndH1.js
+++ b/modules/log/checkTitleAndH1.js
@@ -1,21 +1,17 @@
+import { logError } from "./utilities/logError.js"
+
 export function checkTitleAndH1(document, filePath, errors) {
   // Get the <title> and <h1> elements
   let title = document.querySelector('title');
   let h1 = document.querySelector('h1');
 
-  if (title && h1) {
-    // Check if the text content of <title> and <h1> match
+  // Check if <title> and <h1> are both present
+  if (!title) {
+    logError(document, 'Missing <title> element', filePath, errors);
+  } else if (h1) {
+    // Check if <title> and <h1> text content match
     if (title.textContent.trim() !== h1.textContent.trim()) {
-      if (!errors[filePath]) {
-        errors[filePath] = [];
-      }
-      errors[filePath].push('<title> and <h1> do not match');
+      logError(document, '<title> and <h1> do not match', filePath, errors);
     }
-  } else if (!title) {
-		if (!errors[filePath]) {
-			errors[filePath] = [];
-		}
-		errors[filePath].push('Missing <title> element');
-    
   }
 }

--- a/modules/log/utilities/getPath.js
+++ b/modules/log/utilities/getPath.js
@@ -1,0 +1,24 @@
+export const getPath = (node) => {
+  let path = [];
+  let parentNode = node.parentElement;  
+
+  while (parentNode && parentNode.nodeType === 1) {  // Only traverse element nodes
+    let tagName = parentNode.tagName.toLowerCase();
+    let id = parentNode.id ? `#${parentNode.id}` : '';  // Check if there's an id
+    let classes = parentNode.classList.length ? `.${parentNode.classList[0]}` : '';  // Use only the first class
+
+    // Prioritize id, then class, then tag name
+    let nodePath = id || classes || tagName;
+
+    path.unshift(nodePath);  // Add the node to the front of the array (top to bottom)
+    parentNode = parentNode.parentElement;  // Move up to the parent element
+  }
+
+  // Remove 'html' from the base of the path if it's present
+  if (path[0] === 'html') {
+    path.shift(); 
+  }
+
+  // Return the path as a string
+  return path.join(' > ');
+};

--- a/modules/log/utilities/logError.js
+++ b/modules/log/utilities/logError.js
@@ -1,0 +1,19 @@
+import { getPath } from './getPath.js';
+
+// Error handler that automatically appends the path
+export const logError = (node, message, filePath, errors) => {
+  const path = getPath(node);  // Get the path of the node
+  let errorMessage = message;
+
+  // Only append the path if it's not empty
+  if (path) {
+    errorMessage += ` \n   (${path})`;  // Append path if it's not an empty string
+  }
+
+  // Ensure errors[filePath] exists
+  if (!errors[filePath]) {
+    errors[filePath] = [];
+  }
+
+  errors[filePath].push(errorMessage);
+};


### PR DESCRIPTION
- Modularized the error logging function and created another component to find the relative path for any error found
- Updated all checks to import new error function rather than having it inline

Errors now have a relative path to where the error occurred (unless the error is at the root of the html file). Examples:

`An invalid 'header' is nested within a '.content-body' 
   (body > #content-wrapper)`

`An <img> element contains the attribute: width 
   (body > #content-wrapper > .content-body > header > .border)`

