### PR TITLE
Update gulp cli to 3.1.0 version: 9624447963

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "gulp": "^4.0.2",
-        "gulp-cli": "^3.0.0",
+        "gulp-cli": "^3.1.0",
         "gulp-filter": "^9.0.1",
         "gulp-jsbeautifier": "^3.0.1",
         "gulp-size": "^5.0.0",
@@ -1605,6 +1605,7 @@
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-5.0.0.tgz",
       "integrity": "sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "detect-file": "^1.0.0",
         "is-glob": "^4.0.3",
@@ -1620,6 +1621,7 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -1632,6 +1634,7 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -1644,6 +1647,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -1653,6 +1657,7 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -1666,6 +1671,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -1678,6 +1684,7 @@
       "resolved": "https://registry.npmjs.org/fined/-/fined-2.0.0.tgz",
       "integrity": "sha512-OFRzsL6ZMHz5s0JrsEr+TpdGNCtrVtnuG3x1yzGNiQHT0yaDnXAj8V/lWcpJVrnoDpcwXcASxAZYbuXda2Y82A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "expand-tilde": "^2.0.2",
         "is-plain-object": "^5.0.0",
@@ -1694,6 +1701,7 @@
       "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-2.0.0.tgz",
       "integrity": "sha512-Gq/a6YCi8zexmGHMuJwahTGzXlAZAOsbCVKduWXC6TlLCjjFRlExMJc4GC2NYPYZ0r/brw9P7CpRgQmlPVeOoA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 10.13.0"
       }
@@ -1979,17 +1987,18 @@
       }
     },
     "node_modules/gulp-cli": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-3.0.0.tgz",
-      "integrity": "sha512-RtMIitkT8DEMZZygHK2vEuLPqLPAFB4sntSxg4NoDta7ciwGZ18l7JuhCTiS5deOJi2IoK0btE+hs6R4sfj7AA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-3.1.0.tgz",
+      "integrity": "sha512-zZzwlmEsTfXcxRKiCHsdyjZZnFvXWM4v1NqBJSYbuApkvVKivjcmOS2qruAJ+PkEHLFavcDKH40DPc1+t12a9Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@gulpjs/messages": "^1.1.0",
         "chalk": "^4.1.2",
         "copy-props": "^4.0.0",
         "gulplog": "^2.2.0",
         "interpret": "^3.1.1",
-        "liftoff": "^5.0.0",
+        "liftoff": "^5.0.1",
         "mute-stdout": "^2.0.0",
         "replace-homedir": "^2.0.0",
         "semver-greatest-satisfied-range": "^2.0.0",
@@ -3273,10 +3282,11 @@
       }
     },
     "node_modules/liftoff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-5.0.0.tgz",
-      "integrity": "sha512-a5BQjbCHnB+cy+gsro8lXJ4kZluzOijzJ1UVVfyJYZC+IP2pLv1h4+aysQeKuTmyO8NAqfyQAk4HWaP/HjcKTg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-5.0.1.tgz",
+      "integrity": "sha512-wwLXMbuxSF8gMvubFcFRp56lkFV69twvbU5vDPbaw+Q+/rF8j0HKjGbIdlSi+LuJm9jf7k9PB+nTxnsLMPcv2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "extend": "^3.0.2",
         "findup-sync": "^5.0.0",
@@ -4075,6 +4085,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -4305,6 +4316,7 @@
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
       "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "resolve": "^1.20.0"
       },
@@ -7657,9 +7669,9 @@
       }
     },
     "gulp-cli": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-3.0.0.tgz",
-      "integrity": "sha512-RtMIitkT8DEMZZygHK2vEuLPqLPAFB4sntSxg4NoDta7ciwGZ18l7JuhCTiS5deOJi2IoK0btE+hs6R4sfj7AA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-3.1.0.tgz",
+      "integrity": "sha512-zZzwlmEsTfXcxRKiCHsdyjZZnFvXWM4v1NqBJSYbuApkvVKivjcmOS2qruAJ+PkEHLFavcDKH40DPc1+t12a9Q==",
       "dev": true,
       "requires": {
         "@gulpjs/messages": "^1.1.0",
@@ -7667,7 +7679,7 @@
         "copy-props": "^4.0.0",
         "gulplog": "^2.2.0",
         "interpret": "^3.1.1",
-        "liftoff": "^5.0.0",
+        "liftoff": "^5.0.1",
         "mute-stdout": "^2.0.0",
         "replace-homedir": "^2.0.0",
         "semver-greatest-satisfied-range": "^2.0.0",
@@ -8349,9 +8361,9 @@
       }
     },
     "liftoff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-5.0.0.tgz",
-      "integrity": "sha512-a5BQjbCHnB+cy+gsro8lXJ4kZluzOijzJ1UVVfyJYZC+IP2pLv1h4+aysQeKuTmyO8NAqfyQAk4HWaP/HjcKTg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-5.0.1.tgz",
+      "integrity": "sha512-wwLXMbuxSF8gMvubFcFRp56lkFV69twvbU5vDPbaw+Q+/rF8j0HKjGbIdlSi+LuJm9jf7k9PB+nTxnsLMPcv2Q==",
       "dev": true,
       "requires": {
         "extend": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "devDependencies": {
     "gulp": "^4.0.2",
-    "gulp-cli": "^3.0.0",
+    "gulp-cli": "^3.1.0",
     "gulp-filter": "^9.0.1",
     "gulp-jsbeautifier": "^3.0.1",
     "gulp-size": "^5.0.0",


### PR DESCRIPTION
- This was the only other package other than the base gulp v5 package that needed an update.